### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/test/java/org/mule/test/extension/file/common/ConcurrentLockTestCase.java
+++ b/src/test/java/org/mule/test/extension/file/common/ConcurrentLockTestCase.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.mule.runtime.core.util.concurrent.Latch;
+import org.mule.runtime.core.api.util.concurrent.Latch;
 import org.mule.extension.file.common.api.AbstractFileSystem;
 import org.mule.extension.file.common.api.FileAttributes;
 import org.mule.extension.file.common.api.command.CopyCommand;


### PR DESCRIPTION
_ Moving more classes to api/internal packages
_ Removing dead code