### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
+++ b/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
@@ -6,7 +6,7 @@
  */
 package org.mule.extension.file.common.api;
 
-import org.mule.runtime.core.message.BaseAttributes;
+import org.mule.runtime.core.api.message.BaseAttributes;
 
 import java.nio.file.Path;
 import java.time.Instant;

--- a/src/main/java/org/mule/extension/file/common/api/FileSystem.java
+++ b/src/main/java/org/mule/extension/file/common/api/FileSystem.java
@@ -10,7 +10,7 @@ import org.mule.extension.file.common.api.lock.PathLock;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.MediaType;
-import org.mule.runtime.core.message.OutputHandler;
+import org.mule.runtime.core.api.message.OutputHandler;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 
 import java.io.InputStream;


### PR DESCRIPTION
_ Moving more classes from org.mule.runtime.core.message to api/internal