### PR TITLE
[W-10678323] Support OS independant file-matching.

### DIFF
--- a/src/main/java/org/mule/extension/file/common/api/matcher/MatchPolicy.java
+++ b/src/main/java/org/mule/extension/file/common/api/matcher/MatchPolicy.java
@@ -12,7 +12,7 @@ import static java.util.Optional.of;
 import java.util.Optional;
 
 /**
- * Criterias used to accept or reject a matcher filter.
+ * Criteria used to accept or reject a matcher filter.
  *
  * @since 1.0
  */

--- a/src/main/java/org/mule/extension/file/common/api/matcher/PathMatcherPredicate.java
+++ b/src/main/java/org/mule/extension/file/common/api/matcher/PathMatcherPredicate.java
@@ -77,7 +77,7 @@ public final class PathMatcherPredicate implements Predicate<String> {
         globPattern = pattern;
       }
       if (nativeMatcher)
-        return getGlobPredicate(globPattern);
+        return getGlobPredicate(GLOB_PREFIX + globPattern);
       regex = globPatternToRegex(globPattern, fileSeparator);
     }
     return Pattern.compile(regex, caseSensitive ? 0 : Pattern.CASE_INSENSITIVE).asPredicate();

--- a/src/main/java/org/mule/extension/file/common/api/matcher/PathMatcherPredicate.java
+++ b/src/main/java/org/mule/extension/file/common/api/matcher/PathMatcherPredicate.java
@@ -31,12 +31,23 @@ public final class PathMatcherPredicate implements Predicate<String> {
   private final Predicate<String> delegate;
 
   /**
-   * Creates a new instance using the given pattern
+   * Creates a new instance using the given pattern using the native implementation and file system rules.
    *
    * @param pattern the pattern to be used to test paths.
    */
   public PathMatcherPredicate(String pattern) {
     delegate = getPredicateForFilename(pattern);
+  }
+
+  /**
+   * Creates a new instance using the given pattern.
+   *
+   * @param pattern         the pattern to be used to test paths.
+   * @param caseSensitive   whether matching is case-sensitive
+   * @param fileSeparator   what separates a path components
+   */
+  public PathMatcherPredicate(String pattern, boolean caseSensitive, String fileSeparator) {
+    delegate = getPredicateForFilename(pattern, caseSensitive, fileSeparator, false);
   }
 
   /**
@@ -50,13 +61,26 @@ public final class PathMatcherPredicate implements Predicate<String> {
   }
 
   private Predicate<String> getPredicateForFilename(String pattern) {
+    return getPredicateForFilename(pattern, true, "ignored", true);
+  }
+
+  private Predicate<String> getPredicateForFilename(String pattern, boolean caseSensitive, String fileSeparator,
+                                                    boolean nativeMatcher) {
+    String regex;
     if (pattern.startsWith(REGEX_PREFIX)) {
-      return Pattern.compile(stripRegexPrefix(pattern)).asPredicate();
-    } else if (pattern.startsWith(GLOB_PREFIX)) {
-      return getGlobPredicate(pattern);
+      regex = pattern.substring(REGEX_PREFIX.length());
     } else {
-      return getGlobPredicate(GLOB_PREFIX + pattern);
+      String globPattern;
+      if (pattern.startsWith(GLOB_PREFIX)) {
+        globPattern = pattern.substring(GLOB_PREFIX.length());
+      } else {
+        globPattern = pattern;
+      }
+      if (nativeMatcher)
+        return getGlobPredicate(globPattern);
+      regex = globPatternToRegex(globPattern, fileSeparator);
     }
+    return Pattern.compile(regex, caseSensitive ? 0 : Pattern.CASE_INSENSITIVE).asPredicate();
   }
 
   private Predicate<String> getGlobPredicate(String pattern) {
@@ -64,7 +88,90 @@ public final class PathMatcherPredicate implements Predicate<String> {
     return path -> matcher.matches(Paths.get(path));
   }
 
-  private String stripRegexPrefix(String pattern) {
-    return pattern.replaceAll(REGEX_PREFIX, "");
+  /** Turns a glob pattern into a regular expression pattern.
+   *
+   *  The glob pattern syntax supported is the one defined for {@link java.nio.file.FileSystem#getPathMatcher(String)}.
+   *
+   * @param globPattern the input glob pattern
+   * @param fileSeparator what's used to separate path components (i.e. "/" or "\")
+   * @return a regular expression
+   */
+  private static String globPatternToRegex(String globPattern, String fileSeparator) {
+    if (fileSeparator.equals("\\"))
+      fileSeparator = "\\\\";
+    int length = globPattern.length();
+    StringBuilder sb = new StringBuilder(length + length / 2).append('^');
+    int bracesLevel = 0;
+    boolean inBracketExpression = false;
+    for (int i = 0; i < length; i++) {
+      char ch = globPattern.charAt(i);
+      if (inBracketExpression) {
+        if (ch == '[')
+          sb.append('\\'); // this is so character classes (e.g. [:alnum:] ) don't work
+        sb.append(ch);
+        if (ch == ']') {
+          inBracketExpression = false;
+        }
+        continue;
+      }
+      switch (ch) {
+        case '\\':
+          if (i + 1 < length) {
+            char nextCh = globPattern.charAt(++i);
+            sb.append(Pattern.quote(String.valueOf(nextCh)));
+          }
+          break;
+        case '?':
+          sb.append('.');
+          break;
+        case '*':
+          if (i + 1 < length && globPattern.charAt(i + 1) == '*') {
+            sb.append(".*");
+            i++;
+          } else {
+            sb.append("[^").append(fileSeparator).append("]*");
+          }
+          break;
+        case '{':
+          if (globPattern.substring(i + 1).indexOf('}') == -1) {
+            sb.append("\\{");
+          } else {
+            sb.append("(");
+            bracesLevel++;
+          }
+          break;
+        case '}':
+          if (bracesLevel == 0) {
+            sb.append(ch);
+          } else {
+            sb.append(')');
+            bracesLevel--;
+          }
+          break;
+        case ',':
+          if (bracesLevel == 0)
+            sb.append(ch);
+          else
+            sb.append('|');
+          break;
+        case '[':
+          inBracketExpression = true;
+          sb.append(ch);
+          if (i + 1 < length && globPattern.charAt(i + 1) == '!') {
+            sb.append('^');
+            i++;
+          }
+          break;
+        case '.':
+        case '(':
+        case ')':
+        case '|':
+          sb.append('\\');
+        default:
+          sb.append(ch);
+      }
+    }
+    sb.append('$');
+    return sb.toString();
   }
 }

--- a/src/test/java/org/mule/extension/file/common/api/matcher/PathMatcherPredicateTestCase.java
+++ b/src/test/java/org/mule/extension/file/common/api/matcher/PathMatcherPredicateTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.extension.file.common.api.matcher;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+public class PathMatcherPredicateTestCase {
+
+  @Test
+  public void globPattern1() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("*.txt", true, "/");
+    assertTrue(pmp.test("hello.txt"));
+    assertFalse(pmp.test("hello.TXT"));
+    assertTrue(pmp.test(".txt"));
+    assertFalse(pmp.test("hello.csv"));
+    assertFalse(pmp.test("hello@txt"));
+  }
+
+  @Test
+  public void globPattern2() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("s?t.txt", true, "/");
+    assertTrue(pmp.test("sat.txt"));
+    assertTrue(pmp.test("sit.txt"));
+    assertFalse(pmp.test("st.txt"));
+  }
+
+  @Test
+  public void globPatternWithSpecialCharacters() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("\\()|\\{.txt", true, "/");
+    assertTrue(pmp.test("()|{.txt"));
+    assertFalse(pmp.test("x|{.txt"));
+  }
+
+  @Test
+  public void globPatternStarsAndPathSeparator() {
+    PathMatcherPredicate pmp;
+
+    pmp = new PathMatcherPredicate("*", true, "/");
+    assertFalse(pmp.test("a/b"));
+    assertTrue(pmp.test("a\\b"));
+    pmp = new PathMatcherPredicate("**", true, "/");
+    assertTrue(pmp.test("a/b"));
+
+    pmp = new PathMatcherPredicate("*", true, "\\");
+    assertFalse(pmp.test("a\\b"));
+    assertTrue(pmp.test("a/b"));
+    pmp = new PathMatcherPredicate("**", true, "\\");
+    assertTrue(pmp.test("a\\b"));
+  }
+
+  @Test
+  public void globPatternWithBraces() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("*.{java,clas?}", true, "/");
+    assertTrue(pmp.test("File.java"));
+    assertTrue(pmp.test("File.class"));
+    assertTrue(pmp.test("File.clase"));
+    assertFalse(pmp.test("File.txt"));
+  }
+
+  @Test
+  public void globPatternWithEscapes() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("\\{a,b}", true, "/");
+    assertTrue(pmp.test("{a,b}"));
+  }
+
+  @Test
+  public void globPatternWithBrackets() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("b[aei{}]d", true, "/");
+    assertTrue(pmp.test("bad"));
+    assertTrue(pmp.test("bed"));
+    assertTrue(pmp.test("bid"));
+    assertTrue(pmp.test("b{d"));
+    assertFalse(pmp.test("b.d"));
+  }
+
+  @Test
+  public void globPatternWithNegativeBrackets() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("b[!aei]d", true, "/");
+    assertFalse(pmp.test("bad"));
+    assertFalse(pmp.test("bed"));
+    assertFalse(pmp.test("bid"));
+    assertTrue(pmp.test("b.d"));
+  }
+
+  @Test
+  public void globPatternWithBracketsAndEscape() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("b[\\]]d", true, "/");
+    assertTrue(pmp.test("b]d"));
+    assertFalse(pmp.test("bad"));
+  }
+
+  @Test
+  public void globPatternWithBracketsRegexQuoting() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("\\Qa", true, "/");
+    assertTrue(pmp.test("Qa"));
+    assertFalse(pmp.test("a"));
+  }
+
+  @Test
+  public void globPatternWithBracketsAndMisplacedRegex() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("a[[:digit:]]z", true, "/");
+    assertFalse(pmp.test("a9z"));
+    assertTrue(pmp.test("ad]z"));
+  }
+
+  @Test
+  public void regexPattern1() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("regex:.*\\.txt", true, "/");
+    assertTrue(pmp.test("hello.txt"));
+    assertTrue(pmp.test(".txt"));
+    assertFalse(pmp.test("hello.csv"));
+  }
+
+  @Test
+  public void caseInsensitiveGlobPattern() {
+    PathMatcherPredicate pmp = new PathMatcherPredicate("*.txt", false, "/");
+    assertTrue(pmp.test("hello.txt"));
+    assertTrue(pmp.test("hello.TXT"));
+  }
+
+}


### PR DESCRIPTION
This support enables client code to specify whether case is signigicative and the path separator character.

If neither is speficied, the OS dependent implementation is used. If either option is set, a custom implementation is employed instead.