### PR TITLE
TD-0163189  - Update AbstractFileAttributes - Getter for fileName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven.helper.plugin.version>3.3.0</maven.helper.plugin.version>
 
         <ftp-connector.version>2.0.0-SNAPSHOT</ftp-connector.version>
-        <sftp-connector.version>2.1.0-SNAPSHOT</sftp-connector.version>
+        <sftp-connector.version>1.6.2-SNAPSHOT</sftp-connector.version> <!-- SFTP v2 doesn't not use the file-commons project-->
         <file-connector.version>2.0.0-SNAPSHOT</file-connector.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
         <docker.skip>${skipTests}</docker.skip>
         <maven.helper.plugin.version>3.3.0</maven.helper.plugin.version>
 
+        <ftp-connector.version>2.0.0-SNAPSHOT</ftp-connector.version>
+        <sftp-connector.version>2.1.0-SNAPSHOT</sftp-connector.version>
+        <file-connector.version>2.0.0-SNAPSHOT</file-connector.version>
     </properties>
 
     <dependencies>
@@ -165,19 +168,19 @@
                     <dependency>
                         <groupId>org.mule.connectors</groupId>
                         <artifactId>mule-ftp-connector</artifactId>
-                        <version>2.0.0-SNAPSHOT</version>
+                        <version>${ftp-connector.version}</version>
                         <classifier>mule-plugin</classifier>
                     </dependency>
                     <dependency>
                         <groupId>org.mule.connectors</groupId>
                         <artifactId>mule-sftp-connector</artifactId>
-                        <version>2.0.0-SNAPSHOT</version>
+                        <version>${sftp-connector.version}</version>
                         <classifier>mule-plugin</classifier>
                     </dependency>
                     <dependency>
                         <groupId>org.mule.connectors</groupId>
                         <artifactId>mule-file-connector</artifactId>
-                        <version>2.0.0-SNAPSHOT</version>
+                        <version>${file-connector.version}</version>
                         <classifier>mule-plugin</classifier>
                     </dependency>
                 </dependencies>

--- a/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
+++ b/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
@@ -73,7 +73,7 @@ public abstract class AbstractFileAttributes implements FileAttributes, Serializ
   }
 
   /**
-   * {@inheritDoc}
+   * @return The file's name
    */
   public String getFileName() {
     return fileName;

--- a/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
+++ b/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
@@ -75,7 +75,6 @@ public abstract class AbstractFileAttributes implements FileAttributes, Serializ
   /**
    * {@inheritDoc}
    */
-  @Override
   public String getFileName() {
     return fileName;
   }

--- a/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
+++ b/src/main/java/org/mule/extension/file/common/api/AbstractFileAttributes.java
@@ -72,6 +72,14 @@ public abstract class AbstractFileAttributes implements FileAttributes, Serializ
     return fileName;
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getFileName() {
+    return fileName;
+  }
+
   protected LocalDateTime asDateTime(Instant instant) {
     return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
   }

--- a/src/test/munit/integration-test-case.xml
+++ b/src/test/munit/integration-test-case.xml
@@ -12,7 +12,7 @@
         http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd
         http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd">
 
-    <munit:config name="integration-test-case"/>
+    <munit:config name="integration-test-case" minMuleVersion="4.3.0"/>
 
     <munit:test name="integration-test" description="Perform simple operations with all core components that uses File Commons">
         <munit:execution>
@@ -37,9 +37,8 @@
                         <sftp:content >SFTP</sftp:content>
                     </sftp:write>
                     <sftp:list config-ref="sftp-config" directoryPath="#[vars.dir]"/>
-                    <sftp:read config-ref="sftp-config" path="#[output text/plain --- payload[0].payload]"/>
                     <munit-tools:store key="SFTP">
-                        <munit-tools:value>#[payload]</munit-tools:value>
+                        <munit-tools:value>#[output text/plain --- payload[0].payload]</munit-tools:value>
                     </munit-tools:store>
                     <sftp:delete config-ref="sftp-config" path="#[vars.dir]"/>
                 </route>

--- a/src/test/munit/integration-test-case.xml
+++ b/src/test/munit/integration-test-case.xml
@@ -37,8 +37,9 @@
                         <sftp:content >SFTP</sftp:content>
                     </sftp:write>
                     <sftp:list config-ref="sftp-config" directoryPath="#[vars.dir]"/>
+                    <sftp:read config-ref="sftp-config" path="#[output text/plain --- payload[0].payload]"/>
                     <munit-tools:store key="SFTP">
-                        <munit-tools:value>#[output text/plain --- payload[0].payload]</munit-tools:value>
+                        <munit-tools:value>#[payload]</munit-tools:value>
                     </munit-tools:store>
                     <sftp:delete config-ref="sftp-config" path="#[vars.dir]"/>
                 </route>


### PR DESCRIPTION
Resolving issue about Team Dependency -> TD-0163189
```
Missing getFileName() in org.mule.extension.file.common.api.AbstractFileAttributes
```